### PR TITLE
add external id

### DIFF
--- a/src/track.ts
+++ b/src/track.ts
@@ -3,6 +3,7 @@ import { ComponentSettings, MCEvent } from '@managed-components/types'
 const USER_DATA: Record<string, { hashed?: boolean }> = {
   email: { hashed: true },
   phone_number: { hashed: true },
+  external_id: { hashed: true }
 }
 
 const getTtclid = (event: MCEvent) => {


### PR DESCRIPTION
TikTok allows us to track users based on an external id: https://ads.tiktok.com/help/article/events-api?lang=en

 