### PR TITLE
Allow the payload to set the event id

### DIFF
--- a/src/track.ts
+++ b/src/track.ts
@@ -23,7 +23,7 @@ const getBaseRequestBody = (
   settings: ComponentSettings
 ) => {
   const { client, payload } = event
-  const eventId = String(Math.round(Math.random() * 100000000000000000))
+  const eventId = payload.event_id || String(Math.round(Math.random() * 100000000000000000))
 
   const body: { [k: string]: any } = {
     event:


### PR DESCRIPTION
This will help in the deduplication process. On the UI side the `Event ID` field should be added too.